### PR TITLE
feat: 道路交通法に対応

### DIFF
--- a/core/domain/src/main/java/blue/starry/tokidokiroppou/core/domain/model/LawCode.kt
+++ b/core/domain/src/main/java/blue/starry/tokidokiroppou/core/domain/model/LawCode.kt
@@ -10,6 +10,7 @@ enum class LawCategory(val displayName: String) {
     COMMERCIAL_RELATED("商法関連"),
     ADMINISTRATIVE_SCRIVENER("行政書士業務関連"),
     INFORMATION("情報関連法"),
+    OTHERS("その他"),
 }
 
 @Serializable
@@ -168,5 +169,12 @@ enum class LawCode(
         lawId = "414AC0000000153",
         displayName = "電子署名等に係る地方公共団体情報システム機構の認証業務に関する法律",
         category = LawCategory.INFORMATION,
+    ),
+
+    // その他
+    ROAD_TRAFFIC_LAW(
+        lawId = "335AC0000000105",
+        displayName = "道路交通法",
+        category = LawCategory.OTHERS,
     ),
 }


### PR DESCRIPTION
## Summary
- `LawCategory` に「その他」カテゴリを新設
- `LawCode` に道路交通法 (昭和35年法律第105号) を追加
- 設定画面は既存の動的表示ロジックにより自動的に「その他」グループが表示される

Closes #36

## Test plan
- [ ] 設定画面で「その他」グループが最後に表示されることを確認
- [ ] 道路交通法のチェックボックスが正しく動作することを確認
- [ ] 道路交通法を有効にした状態で通知が届くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)