### PR TITLE
feat: 通知のアクションに「共有」を追加

### DIFF
--- a/core/data/src/main/java/blue/starry/tokidokiroppou/core/data/notification/ArticleNotificationSender.kt
+++ b/core/data/src/main/java/blue/starry/tokidokiroppou/core/data/notification/ArticleNotificationSender.kt
@@ -117,8 +117,12 @@ class ArticleNotificationSender @Inject constructor(
         )
     }
 
+    private fun getArticleShareText(article: Article, useHalfWidthParentheses: Boolean): String {
+        return "${article.lawCode.displayName} ${article.displayTitle(useHalfWidthParentheses)}\n${article.fullText(useHalfWidthParentheses)}"
+    }
+
     private fun createCopyIntent(article: Article, useHalfWidthParentheses: Boolean): PendingIntent {
-        val fullText = "${article.lawCode.displayName} ${article.displayTitle(useHalfWidthParentheses)}\n${article.fullText(useHalfWidthParentheses)}"
+        val fullText = getArticleShareText(article, useHalfWidthParentheses)
         val intent = Intent(context, CopyActionReceiver::class.java).apply {
             action = CopyActionReceiver.ACTION_COPY
             putExtra(CopyActionReceiver.EXTRA_TEXT, fullText)
@@ -133,7 +137,7 @@ class ArticleNotificationSender @Inject constructor(
     }
 
     private fun createShareIntent(article: Article, useHalfWidthParentheses: Boolean): PendingIntent {
-        val fullText = "${article.lawCode.displayName} ${article.displayTitle(useHalfWidthParentheses)}\n${article.fullText(useHalfWidthParentheses)}"
+        val fullText = getArticleShareText(article, useHalfWidthParentheses)
         // Android 12+ では BroadcastReceiver から Activity を起動する trampoline パターンが
         // ブロックされるため、PendingIntent.getActivity() で直接 Sharesheet を起動する
         val sendIntent = Intent(Intent.ACTION_SEND).apply {


### PR DESCRIPTION
## Summary
- 通知のアクションボタンに「共有」を追加し、Android Sharesheet を起動できるようにした
- `ShareActionReceiver` を新規作成し、`CopyActionReceiver` と同じパターンで実装
- アクションの順序は Issue の指定通り「コピー」「共有」「保存」

Closes #43

## Test plan
- [ ] 条文通知を受け取り、「共有」アクションボタンが表示されることを確認
- [ ] 「共有」をタップして Android Sharesheet が起動することを確認
- [ ] 共有されるテキストが「コピー」でコピーされるものと同じ内容であることを確認
- [ ] 「コピー」「保存」ボタンが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)