### PR TITLE
feat: ArticleCard に e-Gov 法令検索へのリンクを追加

### DIFF
--- a/core/ui/src/main/java/blue/starry/tokidokiroppou/core/ui/component/ArticleCard.kt
+++ b/core/ui/src/main/java/blue/starry/tokidokiroppou/core/ui/component/ArticleCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.BookmarkBorder
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -114,6 +115,12 @@ fun ArticleCard(
                             }
                             DropdownMenuItem(
                                 text = { Text("e-Gov 法令検索を開く") },
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Default.OpenInBrowser,
+                                        contentDescription = null,
+                                    )
+                                },
                                 onClick = {
                                     menuExpanded = false
                                     uriHandler.openUri("$EGOV_LAW_URL_BASE${article.lawCode.lawId}")


### PR DESCRIPTION
## Summary
- `ArticleCard` の右上に3点ドットのオーバーフローメニューを追加
- メニュー内に「e-Gov 法令検索を開く」項目を配置し、タップで `https://laws.e-gov.go.jp/law/{lawId}` をブラウザで開く
- Material 3 の `DropdownMenu` / `DropdownMenuItem` コンポーネントを使用

Closes #44

## Test plan
- [ ] ホーム画面の ArticleCard に3点ドットアイコンが表示されることを確認
- [ ] アイコンタップでドロップダウンメニューが表示されることを確認
- [ ] 「e-Gov 法令検索を開く」をタップして該当法令のページがブラウザで開くことを確認
- [ ] 法令一覧画面の ArticleCard でも同様に動作することを確認
- [ ] ブックマーク機能が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)