### PR TITLE
条文詳細画面に前後ナビゲーションを追加

### DIFF
--- a/core/data/src/main/java/blue/starry/tokidokiroppou/core/data/db/ArticleDao.kt
+++ b/core/data/src/main/java/blue/starry/tokidokiroppou/core/data/db/ArticleDao.kt
@@ -10,6 +10,9 @@ interface ArticleDao {
     @Query("SELECT * FROM articles WHERE lawCode = :lawCode")
     suspend fun getByLawCode(lawCode: String): List<ArticleEntity>
 
+    @Query("SELECT * FROM articles WHERE lawCode = :lawCode ORDER BY orderIndex ASC, id ASC")
+    suspend fun getByLawCodeOrdered(lawCode: String): List<ArticleEntity>
+
     @Query("SELECT * FROM articles WHERE lawCode IN (:lawCodes) ORDER BY RANDOM() LIMIT 1")
     suspend fun getRandomByLawCodes(lawCodes: List<String>): ArticleEntity?
 

--- a/core/data/src/main/java/blue/starry/tokidokiroppou/core/data/repository/LawRepositoryImpl.kt
+++ b/core/data/src/main/java/blue/starry/tokidokiroppou/core/data/repository/LawRepositoryImpl.kt
@@ -35,7 +35,7 @@ class LawRepositoryImpl @Inject constructor(
 ) : LawRepository {
 
     override suspend fun getArticles(lawCode: LawCode): List<Article> {
-        val cached = articleDao.getByLawCode(lawCode.name).mapNotNull { it.toDomain() }
+        val cached = articleDao.getByLawCodeOrdered(lawCode.name).mapNotNull { it.toDomain() }
         if (cached.isNotEmpty()) {
             return cached
         }

--- a/feature/home/src/main/java/blue/starry/tokidokiroppou/feature/home/ui/HomeScreen.kt
+++ b/feature/home/src/main/java/blue/starry/tokidokiroppou/feature/home/ui/HomeScreen.kt
@@ -16,6 +16,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.filled.Link
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
@@ -116,6 +118,31 @@ fun HomeScreen(
                         .padding(16.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        androidx.compose.material3.IconButton(
+                            onClick = { state.previousArticle?.let(viewModel::navigateTo) },
+                            enabled = state.previousArticle != null,
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "前の条文へ",
+                            )
+                        }
+                        androidx.compose.material3.IconButton(
+                            onClick = { state.nextArticle?.let(viewModel::navigateTo) },
+                            enabled = state.nextArticle != null,
+                        ) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                                contentDescription = "次の条文へ",
+                            )
+                        }
+                    }
+
                     ArticleCard(
                         article = state.article,
                         useHalfWidthParentheses = state.useHalfWidthParentheses,

--- a/feature/home/src/main/java/blue/starry/tokidokiroppou/feature/home/ui/HomeScreenViewModel.kt
+++ b/feature/home/src/main/java/blue/starry/tokidokiroppou/feature/home/ui/HomeScreenViewModel.kt
@@ -25,6 +25,11 @@ class HomeScreenViewModel @Inject constructor(
     private val settingsRepository: ApplicationSettingsRepository,
     private val bookmarkRepository: BookmarkRepository,
 ) : ViewModel() {
+    data class ArticleNavigationTarget(
+        val lawCode: String,
+        val articleNumber: String,
+        val supplementaryProvisionLabel: String? = null,
+    )
 
     private val _uiState = MutableStateFlow<HomeUiState>(HomeUiState.Loading)
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
@@ -86,7 +91,15 @@ class HomeScreenViewModel @Inject constructor(
             if (article != null) {
                 val related = lawRepository.getRelatedArticles(article)
                 val metadata = lawRepository.getLawMetadata(article.lawCode)
-                _uiState.value = HomeUiState.Loaded(article, related, metadata, settings.useHalfWidthParentheses)
+                val navigation = buildNavigationTargets(article)
+                _uiState.value = HomeUiState.Loaded(
+                    article = article,
+                    relatedArticles = related,
+                    lawMetadata = metadata,
+                    useHalfWidthParentheses = settings.useHalfWidthParentheses,
+                    previousArticle = navigation.first,
+                    nextArticle = navigation.second,
+                )
             } else {
                 _uiState.value = HomeUiState.Error("条文を取得できませんでした")
             }
@@ -104,11 +117,39 @@ class HomeScreenViewModel @Inject constructor(
             if (article != null) {
                 val related = lawRepository.getRelatedArticles(article)
                 val metadata = lawRepository.getLawMetadata(article.lawCode)
-                _uiState.value = HomeUiState.Loaded(article, related, metadata, settings.useHalfWidthParentheses)
+                val navigation = buildNavigationTargets(article)
+                _uiState.value = HomeUiState.Loaded(
+                    article = article,
+                    relatedArticles = related,
+                    lawMetadata = metadata,
+                    useHalfWidthParentheses = settings.useHalfWidthParentheses,
+                    previousArticle = navigation.first,
+                    nextArticle = navigation.second,
+                )
             } else {
                 _uiState.value = HomeUiState.Error("条文を取得できませんでした")
             }
         }
+    }
+
+    fun navigateTo(target: ArticleNavigationTarget) {
+        loadSpecificArticle(target.lawCode, target.articleNumber, target.supplementaryProvisionLabel)
+    }
+
+    private suspend fun buildNavigationTargets(article: Article): Pair<ArticleNavigationTarget?, ArticleNavigationTarget?> {
+        val articles = lawRepository.getArticles(article.lawCode)
+        val index = articles.indexOfFirst {
+            it.articleNumber == article.articleNumber &&
+                it.supplementaryProvisionLabel == article.supplementaryProvisionLabel
+        }
+        if (index == -1) return null to null
+        val previous = articles.getOrNull(index - 1)?.let {
+            ArticleNavigationTarget(it.lawCode.name, it.articleNumber, it.supplementaryProvisionLabel)
+        }
+        val next = articles.getOrNull(index + 1)?.let {
+            ArticleNavigationTarget(it.lawCode.name, it.articleNumber, it.supplementaryProvisionLabel)
+        }
+        return previous to next
     }
 }
 
@@ -119,6 +160,8 @@ sealed interface HomeUiState {
         val relatedArticles: List<Article>,
         val lawMetadata: LawMetadata?,
         val useHalfWidthParentheses: Boolean,
+        val previousArticle: HomeScreenViewModel.ArticleNavigationTarget?,
+        val nextArticle: HomeScreenViewModel.ArticleNavigationTarget?,
     ) : HomeUiState
     data object NoLawSelected : HomeUiState
     data class Error(val message: String) : HomeUiState


### PR DESCRIPTION
### Motivation
- 条文詳細ビューで前後の条文に素早く移動できるナビゲーションを実装し、ユーザが隣接する条文を連続して閲覧できるようにするため。

### Description
- `HomeScreenViewModel` に `ArticleNavigationTarget` を追加し、現在表示中の条文から同一法令内の前後条文を解決する `buildNavigationTargets` と遷移実行用の `navigateTo` を実装しました。
- ランダム取得と特定条文取得の両方で前後遷移先を計算して `HomeUiState.Loaded` に `previousArticle`/`nextArticle` として保持するようにしました。
- `HomeScreen` の記事表示上部に左右の矢印ボタンを追加し、`Icons.AutoMirrored.Filled.ArrowBack` / `ArrowForward` を用いて存在する前後条文へ `viewModel.navigateTo(...)` で遷移するようにし、遷移先がない場合はボタンを無効化しました。
- 関連する import と UI 配置を調整しました（該当ファイル: `feature/home/src/main/java/.../HomeScreen.kt`、`HomeScreenViewModel.kt`）。

### Testing
- 実装後に `./gradlew :feature:home:compileDebugKotlin` を実行しましたが、実行環境に Android SDK が設定されていないため `SDK location not found` エラーでビルドは実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97831ec948331b0bfb8df616802a7)