### PR TITLE
fix: Gemini モデルを 3.5 Flash に更新

### DIFF
--- a/core/ai/src/main/java/blue/starry/tokidokiroppou/core/ai/di/AiModule.kt
+++ b/core/ai/src/main/java/blue/starry/tokidokiroppou/core/ai/di/AiModule.kt
@@ -30,7 +30,7 @@ abstract class AiBindsModule {
 }
 
 object AiConstants {
-    const val MODEL_NAME = "gemini-3.1-flash-lite-preview"
+    const val MODEL_NAME = "gemini-3.5-flash"
 }
 
 @Module


### PR DESCRIPTION
## 概要

- AI 機能で使用する Gemini モデルを `gemini-3.1-flash-lite-preview` から `gemini-3.5-flash` に変更しました。

## 背景

`gemini-3.1-flash-lite-preview` が提供終了または利用不可になる可能性があるため、動作確認済みの `gemini-3.5-flash` へ切り替えます。

## 確認

- ユーザー環境での動作確認済み
- `./gradlew check`